### PR TITLE
Bump urllib3 to 2.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -87,7 +87,7 @@ tornado==6.5.1
 traitlets==4.3.2
 typed-ast==1.4.0
 uritemplate==3.0.0
-urllib3==2.6.3
+urllib3==2.7.0
 wcwidth==0.1.7
 webencodings==0.5.1
 widgetsnbextension==3.4.2


### PR DESCRIPTION
Updates urllib3 to 2.7.0 to address open Dependabot security alerts.\n\nValidation:\n- uv pip install --dry-run --python /tmp/dependabot-work/venv-ga/bin/python 'requests==2.32.4' 'urllib3==2.7.0'